### PR TITLE
Implemented Poly.InFillet

### DIFF
--- a/Core/Geom/PolyOps.cs
+++ b/Core/Geom/PolyOps.cs
@@ -61,6 +61,58 @@ public partial class Poly {
       return pb.Build ();
    }
 
+   /// <summary>In-fillets a Poly at a given node (returns null if not possible)</summary>
+   /// If the node number passed in the start or end node of an open pline, this 
+   /// return null. Otherwise, this is an 'interior' node, and there are two segments
+   /// touching at that node (a lead-in segment, and a lead-out segment). If either
+   /// of those segments are curved, or too short to take a in-fillet, this returns null. 
+   /// <param name="radius">In-fillet radius</param>
+   /// <param name="left">Indicates how the in-fillet arc winds around target node</param>
+   public Poly? InFillet (int node, double radius, bool left) {
+      if (radius.IsZero ()) return null;
+      // Handle the special case where we are in-filleting at node 0 of a 
+      // closed Poly (by rolling the poly and making a in-fillet at N-1)
+      if (IsClosed && (node == 0 || node == Count))
+         return Roll (1).InFillet (Count - 1, radius, left);
+
+      // If this is not an interior node, or if one of the two segments attached
+      // to the node is either an arc or too short, we return null
+      if (node <= 0 || node >= Count) return null;
+      Seg s1 = this[node - 1], s2 = this[node];
+      if (s1.IsArc || s2.IsArc || s1.Length <= radius || s2.Length <= radius) return null;
+
+      // Use a PolyBuilder to build the in-filleted poly. The target node where
+      // the in-fillet is to be added is 'node'
+      PolyBuilder pb = new ();
+      for (int i = 0; i < mPts.Length; i++) {
+         Point2 pt = mPts[i];
+         // If we are going to add the target node, shift it forward by dist2
+         // along the lead-out segment slope (this is the end of the in-fillet). See the code
+         // below that would have already added the beginning of the in-fillet (the
+         // i == node - 1 check)
+         if (i == node) pt = pt.Polar (radius, s2.Slope);
+
+         // This code adds all the other nodes (they could be the starts of line or arc
+         // segments, and we handle both by looking through the mExtra array). Note that
+         // we directly read the mExtra array rather than use Seg objects for better
+         // performance
+         if (HasArcs && i < mExtra.Length) {
+            var extra = mExtra[i];
+            if ((extra.Flags & EFlags.Arc) != 0) pb.Arc (pt, extra.Center, extra.Flags);
+            else pb.Line (pt);
+         } else
+            pb.Line (pt);
+
+         // If we are heading towards the target node, add an new node for the beginning
+         // of the in-fillet, by moving backwards by dist1 along the lead-in segment slope
+         if (i == node - 1)
+            pb.Arc (s2.A.Polar (-radius, s1.Slope), s2.A, left ? EFlags.CW : EFlags.CCW);
+      }
+      // Done, close the poly if needed and return it
+      if (IsClosed) pb.Close ();
+      return pb.Build ();
+   }
+
    /// <summary>'Rolls' a closed Poly so that node N becomes the starting node</summary>
    /// This returns a new Poly that looks identical, but whose start point is different. 
    /// It is mainly used to simplify some routines (like Chamfer) so they never have to 

--- a/Test/Geom/TPolyOps.cs
+++ b/Test/Geom/TPolyOps.cs
@@ -1,0 +1,22 @@
+﻿// ────── ╔╗                                                                                   TEST
+// ╔═╦╦═╦╦╬╣ TPolyOps.cs
+// ║║║║╬║╔╣║ Tests for the Poly mangler methods
+// ╚╩═╩═╩╝╚╝ ───────────────────────────────────────────────────────────────────────────────────────
+namespace Nori.Testing;
+
+[Fixture (19, "Poly node mangler tests", "Geom")]
+class PolyOpsTests {
+   [Test (58, "Poly in-fillet tests")]
+   void Test1 () {
+      Poly rect = Poly.Rectangle (0, 0, 200, 100);
+      Poly? poly;
+      poly = rect.InFillet (0, 25, left: true); poly!.Is ("M200,0V100H0V25Q25,0,-1Z");
+      poly = rect.InFillet (0, 25, left: false); poly!.Is ("M200,0V100H0V25Q25,0,3Z");
+
+      poly = rect.InFillet (1, 25, left: true); poly!.Is ("M0,0H175Q200,25,-1V100H0Z");
+      poly = rect.InFillet (1, 25, left: false); poly!.Is ("M0,0H175Q200,25,3V100H0Z");
+
+      poly = rect.InFillet (4, 25, left: true); poly!.Is ("M200,0V100H0V25Q25,0,-1Z");
+      poly = rect.InFillet (4, 25, left: false); poly!.Is ("M200,0V100H0V25Q25,0,3Z");
+   }
+}


### PR DESCRIPTION
Poly in-fillet method implemented, which does not concern itself with major/minor arc.

Note: Left (of the flow) indicator is used to determine the winding of the injected fillet arc about the 'target node'.
This should hold for all cases.

Test cases: Basic test case added. [Nori must be fully testable on its own.]