### PR TITLE
Implement a new Poly.Arc( ) method

### DIFF
--- a/Core/Geom/Poly.cs
+++ b/Core/Geom/Poly.cs
@@ -56,7 +56,6 @@ public partial class Poly {
    /// <summary>Make a single-line Poly</summary>
    public static Poly Line (Point2 pt, Point2 pt2)
       => new ([pt, pt2], [], 0);
-
    /// <summary>Make a single-line Poly</summary>
    public static Poly Line (double x1, double y1, double x2, double y2)
       => Line (new (x1, y1), new (x2, y2));

--- a/Core/Geom/Poly.cs
+++ b/Core/Geom/Poly.cs
@@ -22,6 +22,28 @@ public partial class Poly {
       return new Poly ([a, b], [new Extra (center, ccw ? EFlags.CCW : EFlags.CW)], EFlags.HasArcs);
    }
 
+   /// <summary>Make a single-arc Poly</summary>
+   public static Poly Arc (Point2 start, double startTangentAngle, Point2 end) {
+      Point2 tangentPt = start.Polar (100, startTangentAngle); // An arbitrary tangent point
+      int arcDir = end.Side (start, tangentPt); // CW (-1), CCW (+1), Line (0)
+
+      // The center of the arc is the intersection of the below two lines:
+      // Line 1: Line perpendicular to the tangent (i.e the normal)
+      Point2 normalEndPt = start.Polar (100, startTangentAngle + HalfPI * arcDir);
+      // Line 2: Perpendicular bisector of the chord connecting start and end point
+      Point2 mid = start.Midpoint (end);
+      Point2 bisectorEndPt = mid.Polar (100, start.AngleTo (end) + HalfPI * arcDir);
+      var cen = LineXLine (start, normalEndPt, mid, bisectorEndPt);
+
+      var (sa, ea) = (cen.AngleTo (start), cen.AngleTo (end));
+      if (arcDir < 0) while (ea > sa) ea -= TwoPI;
+      else while (ea < sa) ea += TwoPI;
+
+      // If the end point lies along the tangent, return a line from start to end.
+      if (arcDir == 0 || cen.IsNil) return Line (start, end);
+      return Arc (cen, cen.DistTo (start), sa, ea, arcDir > 0);
+   }
+
    /// <summary>Make a full-circle Poly</summary>
    public static Poly Circle (Point2 pt, double radius) {
       Point2 a = pt + new Vector2 (radius, 0);
@@ -34,6 +56,7 @@ public partial class Poly {
    /// <summary>Make a single-line Poly</summary>
    public static Poly Line (Point2 pt, Point2 pt2)
       => new ([pt, pt2], [], 0);
+
    /// <summary>Make a single-line Poly</summary>
    public static Poly Line (double x1, double y1, double x2, double y2)
       => Line (new (x1, y1), new (x2, y2));

--- a/Core/Geom/Poly.cs
+++ b/Core/Geom/Poly.cs
@@ -29,10 +29,10 @@ public partial class Poly {
 
       // The center of the arc is the intersection of the below two lines:
       // Line 1: Line perpendicular to the tangent (i.e the normal)
-      Point2 normalEndPt = start.Polar (100, startTangentAngle + HalfPI * arcDir);
+      Point2 normalEndPt = start.Polar (100, startTangentAngle + HalfPI);
       // Line 2: Perpendicular bisector of the chord connecting start and end point
       Point2 mid = start.Midpoint (end);
-      Point2 bisectorEndPt = mid.Polar (100, start.AngleTo (end) + HalfPI * arcDir);
+      Point2 bisectorEndPt = mid.Polar (100, start.AngleTo (end) + HalfPI);
       var cen = LineXLine (start, normalEndPt, mid, bisectorEndPt);
 
       var (sa, ea) = (cen.AngleTo (start), cen.AngleTo (end));

--- a/Test/Geom/TPoly.cs
+++ b/Test/Geom/TPoly.cs
@@ -21,6 +21,20 @@ class PolyTests {
       var p = Poly.Parse ("M0,0 H10 V3 Q8,5,1 H2 Q0,3,-1 Z");
       p.Is ("M0,0H10V3Q8,5,1H2Q0,3,-1Z");
       p.IsLine.IsFalse (); p.IsOpen.IsFalse ();
+
+      var p2 = Poly.Arc (new (0, 1), 1, 180.D2R(), 0, false);
+      p2.A.Is ("(-1,1)"); p2.B.Is ("(1,1)");
+      p2.Is ("M-1,1Q1,1,-2"); p2.HasArcs.IsTrue (); p2.IsOpen.IsTrue (); 
+      var p3 = Poly.Arc (new (0, 1), 1, 180.D2R (), 0, true);
+      p3.Is ("M-1,1Q1,1,2"); p3.HasArcs.IsTrue (); p3.IsOpen.IsTrue ();
+      var p4 = Poly.Arc (new (0, 0), 90.D2R (), new (10, 0));
+      p4.A.Is ("(0,0)"); p4.B.Is ("(10,0)");
+      p4.Is ("M0,0Q10,0,-2"); p4.HasArcs.IsTrue (); p4.IsOpen.IsTrue ();
+      var p5 = Poly.Arc (new (0, 0), 90.D2R (), new (-10, 0));
+      p5.Is ("M0,0Q-10,0,2"); p5.HasArcs.IsTrue (); p5.IsOpen.IsTrue ();
+      Poly.Arc (new (0, 0), 0, (10, 0)).IsLine.IsTrue ();
+      var p6 = Poly.Arc (new (0, 0), 45.D2R (), (-5, -5));
+      p6.HasArcs.IsFalse (); p6.Is ("M0,0L-5,-5");
    }
 
    [Test (25, "Discretization, Seg enumerate, Xfm")]


### PR DESCRIPTION
Following the ArcTangent command in PIX (under [this ](https://github.com/metamation/Pix/pull/87)PR), below changes have been done:

1. Added a new method `Poly.Arc (start, startTangentAngle, end) { }` under Poly class.
2. Added corresponding test cases in '**Basic Constructors**' tests.