### PR TITLE
Improved handling of Enums in CurlWriter / CurlReader #46

### DIFF
--- a/Core/IO/AuType.cs
+++ b/Core/IO/AuType.cs
@@ -224,14 +224,52 @@ class AuType {
       if (mEnumMap == null) {
          mEnumMap = new ();
          var (names, values) = (Enum.GetNames (mType), Enum.GetValues (mType));
-         for (int i = 0; i < names.Length; i++) mEnumMap.Add (names[i], values.GetValue (i)!);
+         for (int i = 0; i < names.Length; i++) mEnumMap.Add (names[i], NormalizedEnumInteger (mType, values.GetValue (i)!));
       }
-      return mEnumMap[stm.TakeUntil (CurlReader.NameStop, true)];
+      var desc = stm.TakeUntil (CurlReader.NameStop, true);
+      if (mEnumMap.TryGetValue (desc, out var value))
+         return ReconstructEnumObject (value);
+      if (mType.HasAttribute<FlagsAttribute> ()) {
+         ulong bits = 0;
+         foreach (var r in desc.Split ((byte)','))
+            bits |= mEnumMap[desc[r]];
+         return ReconstructEnumObject (bits);
+      }
+      if (desc[0] is >= (byte)'0' and <= (byte)'9') // Outlier enum value
+         return ReconstructEnumObject (ulong.Parse (desc));
+      throw new NotImplementedException (mType.FullName!);
+
+      // Reconstructs enum's backing-type compatible integral value object, given normalized value
+      object ReconstructEnumObject (ulong v) {
+         return Type.GetTypeCode (mType) switch {
+            TypeCode.Int32 => Enum.ToObject (mType, (int)v), // Default backing type
+            TypeCode.UInt32 => Enum.ToObject (mType, (uint)v),
+            TypeCode.Int64 => Enum.ToObject (mType, (long)v),
+            TypeCode.UInt64 => Enum.ToObject (mType, (ulong)v),
+            TypeCode.Int16 => Enum.ToObject (mType, (short)v),
+            TypeCode.UInt16 => Enum.ToObject (mType, (ushort)v),
+            TypeCode.Byte => Enum.ToObject (mType, (byte)v),
+            TypeCode.SByte => Enum.ToObject (mType, (sbyte)v),
+            _ => throw new BadCaseException (mType.FullName!)
+         };
+      }
    }
-   SymTable<object>? mEnumMap;
-   // REFINE: Handle [Flags] enums
-   // REFINE: Handle the case where the enum value has been written out as an integer (because it
-   // did not match any of the tags)
+   SymTable<ulong>? mEnumMap;
+
+   /// <summary>Normalizes given enum's (integral) value to UInt64</summary>
+   static ulong NormalizedEnumInteger (Type enumType, object o) {
+      return Type.GetTypeCode (enumType) switch { // Note: Unboxing needs exact cast
+         TypeCode.Int32 => (ulong)(int)o, // Default backing type
+         TypeCode.UInt32 => (ulong)(uint)o,
+         TypeCode.Int64 => (ulong)(long)o,
+         TypeCode.UInt64 => (ulong)o,
+         TypeCode.Int16 => (ulong)(short)o,
+         TypeCode.UInt16 => (ulong)(ushort)o,
+         TypeCode.Byte => (ulong)(byte)o,
+         TypeCode.SByte => (ulong)(sbyte)o,
+         _ => throw new BadCaseException (enumType.FullName!)
+      };
+   }
 
    // Write methods ------------------------------------------------------------
    /// <summary>Writes an object of a type that is tagged as [AuPrimitive]</summary>
@@ -286,18 +324,41 @@ class AuType {
    /// we build a map that maps each enumeration value (integer) into a byte[] that is a
    /// UTF8 encoding of the string.
    public void WriteEnum (UTFWriter stm, object value) {
-      if (mEnumValues == null) {
-         mEnumValues = [];
-         var (names, values) = (Enum.GetNames (mType), Enum.GetValues (mType));
-         for (int i = 0; i < names.Length; i++)
-            mEnumValues.TryAdd ((int)values.GetValue (i)!, Encoding.UTF8.GetBytes (names[i]));
+      mEnumDescs = [];
+      var (names, values) = (Enum.GetNames (mType), Enum.GetValues (mType));
+      for (int i = 0; i < names.Length; i++)
+         mEnumDescs.TryAdd (NormalizedEnumInteger (mType, values.GetValue (i)!), Encoding.UTF8.GetBytes (names[i]));
+
+      if (mEnumDescs.TryGetValue (NormalizedEnumInteger (mType, value), out var desc)) {
+         stm.Write (desc);
+         return;
       }
-      stm.Write (mEnumValues[(int)value]);
+      if (mType.HasAttribute<FlagsAttribute> ()) {
+         ulong bits = NormalizedEnumInteger (mType, value);
+         bool comma = false;
+         int cBit = Type.GetTypeCode (mType) switch {
+            TypeCode.Int32 or TypeCode.UInt32 => 32, // Default backing type
+            TypeCode.Int16 or TypeCode.UInt16 => 16,
+            TypeCode.Byte or TypeCode.SByte => 8,
+            TypeCode.Int64 or TypeCode.UInt64 => 64,
+            _ => throw new BadCaseException (mType.FullName!)
+         };
+         for (int i = 0; i < cBit; i++) {
+            if ((bits & ((ulong)1 << i)) != 0) {
+               if (comma) stm.Write (',');
+               stm.Write (mEnumDescs[(ulong)1 << i]);
+               comma = true;
+            }
+         }
+         return;
+      }
+      if (!Enum.IsDefined (mType, value)) {
+         stm.Write (NormalizedEnumInteger (mType, value));
+         return;
+      }
+      throw new NotImplementedException ();
    }
-   Dictionary<int, byte[]>? mEnumValues;
-   // REFINE: Handle [Flags] enums
-   // REFINE: Handle the case where the Enum value is not one of the names (write it out as
-   // an integer, and update Read to handle that case)
+   Dictionary<ulong, byte[]>? mEnumDescs;
 
    // Implementation -----------------------------------------------------------
    // Classifies this type (computes the Kind property)

--- a/TData/IO/T009.curl
+++ b/TData/IO/T009.curl
@@ -1,2 +1,2 @@
 ; T009
-(EFlagTest){ SingleBit:Two MultiBit:One,Two MultiBit2:Five Outlier:One,Two,Four }
+(EFlagTest){ SingleBit:Two MultiBit:One,Two MultiBit2:Nine Outlier:7 }

--- a/TData/IO/T009.curl
+++ b/TData/IO/T009.curl
@@ -1,0 +1,2 @@
+; T009
+(EFlagTest){ SingleBit:Two MultiBit:One,Two MultiBit2:Five Outlier:One,Two,Four }

--- a/TData/IO/T010.curl
+++ b/TData/IO/T010.curl
@@ -1,0 +1,2 @@
+; T010
+(EOutlierTest){ InRange:One Outlier:99 }

--- a/Test/Misc/TAuSystem.cs
+++ b/Test/Misc/TAuSystem.cs
@@ -53,6 +53,10 @@ class TAuSystem {
         X Y
       CType2
         JBuf
+      EFlagTest
+         SingleBit MultiBit MultiBit2 Outlier
+      EOutlierTest
+         InRange Outlier
       """;
 
    [Test (61, "Test primitives")]
@@ -165,6 +169,24 @@ class TAuSystem {
 
       message = Crasher (() => CurlWriter.ToFile (new CType2 (), NT.TmpCurl));
       message.Is ("AuException: 64-bit enums are not supported");
+   }
+
+   [Test (70, "Test [Flags] Enum")]
+   void Test7 () {
+      var f0 = new EFlagTest ();
+      Check (f0, "T009.curl", "T009");
+
+      var f1 = (EFlagTest)CurlReader.FromFile (NT.TmpCurl);
+      Check (f1, "T009.curl", "T009");
+   }
+
+   [Test (71, "Test outlier Enum value")]
+   void Test8 () {
+      var f0 = new EOutlierTest ();
+      Check (f0, "T010.curl", "T010");
+
+      var f1 = (EOutlierTest)CurlReader.FromFile (NT.TmpCurl);
+      Check (f1, "T010.curl", "T010");
    }
 
    static string Crasher (Action act) {
@@ -303,4 +325,23 @@ enum EJumpBuffer : ulong { Back = 1, Forward = 2 };
 
 class CType1 { public Location Loc; }
 class CType2 { public EJumpBuffer JBuf; }
+
+// .........................................................
+[Flags]
+enum Bits : uint { One = 0x1, Two = 0x2, Four = 0x4, Five = Four | One }
+
+class EFlagTest {
+   public Bits SingleBit = Bits.Two;
+   public Bits MultiBit = Bits.One | Bits.Two;
+   public Bits MultiBit2 = Bits.Five;
+   public Bits Outlier = (Bits)0x7;
+}
+
+// .........................................................
+enum EType { One = 1, Two }
+
+class EOutlierTest {
+   public EType InRange = (EType)1;
+   public EType Outlier = (EType)99;
+}
 #pragma warning restore 0414, 0649

--- a/Test/Misc/TAuSystem.cs
+++ b/Test/Misc/TAuSystem.cs
@@ -328,12 +328,12 @@ class CType2 { public EJumpBuffer JBuf; }
 
 // .........................................................
 [Flags]
-enum Bits : uint { One = 0x1, Two = 0x2, Four = 0x4, Five = Four | One }
+enum Bits : uint { One = 0x1, Two = 0x2, Eight = 0x8, Nine = Eight | One }
 
 class EFlagTest {
    public Bits SingleBit = Bits.Two;
    public Bits MultiBit = Bits.One | Bits.Two;
-   public Bits MultiBit2 = Bits.Five;
+   public Bits MultiBit2 = Bits.Nine;
    public Bits Outlier = (Bits)0x7;
 }
 


### PR DESCRIPTION
Enums may be seen as some integral type - but, with a fixed set of named integral values.
**Outlier value**: Any value other than the pre-defined ones is considered an arbitrary value, and is serialized as a ulong value.

`[Flags]`Enum allows one to represent a bit-field variable and facilitates working with named bit values in bit-wise operations.
**Outlier value**: Any value which is not some combination of defined bits is considered an arbitrary value, and is serialized as a ulong value.

```
[Flags]
enum Bits : uint { One = 0x1, Two = 0x2, Eight = 0x8, Nine = Eight | One }

class EFlagTest {
   public Bits SingleBit = Bits.Two;
   public Bits MultiBit = Bits.One | Bits.Two;
   public Bits MultiBit2 = Bits.Nine;
   public Bits Outlier = (Bits)7; // Or (Bits)99, etc. Arbitrary/outlier value!
}
```