### PR TITLE
Cleanup poly corner operations in case of circles #83

### DIFF
--- a/Core/Geom/PolyOps.cs
+++ b/Core/Geom/PolyOps.cs
@@ -18,12 +18,11 @@ public partial class Poly {
    /// dist1 is the distance from the corner along the lead-in segment, and dist2
    /// is the distance from the corner along the lead-out segment. 
    public Poly? Chamfer (int node, double dist1, double dist2) {
-      // Handle the special case where we are chamfering at node 0 of a 
+      if (IsCircle) return null; // No chamfer for circles
+      // Handle the special case where we are chamfering at node 0 of a
       // closed Poly (by rolling the poly and making it a chamfer at N-1)
-      if (IsClosed && (node == 0 || node == Count)) {
-         var r = Roll (1);
-         return r.IsCircle ? null : r.Chamfer (Count - 1, dist1, dist2); //No chamfer for circles
-      }
+      if (IsClosed && (node == 0 || node == Count))
+         return Roll (1).Chamfer (Count - 1, dist1, dist2);
 
       // If this is not an interior node, or if one of the two segments attached
       // to the node is either an arc or too short, we return null
@@ -71,13 +70,11 @@ public partial class Poly {
    /// <param name="radius">In-fillet radius</param>
    /// <param name="left">Indicates how the in-fillet arc winds around target node</param>
    public Poly? InFillet (int node, double radius, bool left) {
-      if (radius.IsZero ()) return null;
-      // Handle the special case where we are in-filleting at node 0 of a 
+      if (IsCircle || radius.IsZero ()) return null; // No Infillet for circles
+      // Handle the special case where we are in-filleting at node 0 of a
       // closed Poly (by rolling the poly and making a in-fillet at N-1)
-      if (IsClosed && (node == 0 || node == Count)) {
-         var r = Roll (1);
-         return r.IsCircle ? null : r.InFillet (Count - 1, radius, left); // No Infillet for circles
-      }
+      if (IsClosed && (node == 0 || node == Count))
+         return Roll (1).InFillet (Count - 1, radius, left);
 
       // If this is not an interior node, or if one of the two segments attached
       // to the node is either an arc or too short, we return null
@@ -128,12 +125,11 @@ public partial class Poly {
    /// 'left' indicates how the step gets added w.r.t to the target node
    /// 'pos' indicates the reference position w.r.t the lead-in and lead-out segments
    public Poly? CornerStep (int node, double dist1, double dist2, ECornerOpFlags flags) {
-      // Handle the special case where we are in-filleting at node 0 of a 
+      if (IsCircle) return null; // No Corner-step for circles.
+      // Handle the special case where we are in-filleting at node 0 of a
       // closed Poly (by rolling the poly and making a in-fillet at N-1)
-      if (IsClosed && (node == 0 || node == Count)) {
-         var r = Roll (1);
-         return r.IsCircle ? null : r.CornerStep (Count - 1, dist1, dist2, flags); // No corner step for circles
-      }
+      if (IsClosed && (node == 0 || node == Count))
+         return Roll (1).CornerStep (Count - 1, dist1, dist2, flags);
 
       // If this is not an interior node, or if one of the two segments attached
       // to the node is either an arc or too short, we return null
@@ -191,13 +187,11 @@ public partial class Poly {
    /// of those segments are curved, or too short to take a fillet, this returns null. 
    /// <param name="radius">Fillet radius</param>
    public Poly? Fillet (int node, double radius) {
-      if (radius.IsZero ()) return null;
-      // Handle the special case where we are filleting at node 0 of a 
+      if (IsCircle || radius.IsZero ()) return null; // No Fillet for circles
+      // Handle the special case where we are filleting at node 0 of a
       // closed Poly (by rolling the poly and making a fillet at N-1)
-      if (IsClosed && (node == 0 | node == Count)) {
-         var r = Roll (1);
-         return r.IsCircle ? null : r.Fillet (Count - 1, radius); // No Fillet for circles
-      }
+      if (IsClosed && (node == 0 | node == Count))
+         return Roll (1).Fillet (Count - 1, radius);
 
       // If this is not an interior node, or if one of the two segments attached
       // to the node is either an arc or too short, we return null

--- a/Test/Geom/TPolyOps.cs
+++ b/Test/Geom/TPolyOps.cs
@@ -18,6 +18,10 @@ class PolyOpsTests {
 
       poly = rect.InFillet (4, 25, left: true); poly!.Is ("M200,0V100H0V25Q25,0,-1Z");
       poly = rect.InFillet (4, 25, left: false); poly!.Is ("M200,0V100H0V25Q25,0,3Z");
+
+      Poly cir = Poly.Circle ((0, 0), 50);
+      poly = cir.InFillet (0, 10, true);
+      Assert.IsTrue (poly is null);
    }
 
    [Test (60, "Poly corner-step tests")]


### PR DESCRIPTION
When performing a corner operation at the start or at the end of a closed poly, we roll the poly such that the node in question is falls into the middle of the nodes list. After rolling the poly we then check if the given poly is a circle and if so, null is returned. Correct way here, is not to roll the poly in case of a circle.