### PR TITLE
Fixed the duplicate endpoints in a closed poly issue

### DIFF
--- a/Core/Geom/Poly.cs
+++ b/Core/Geom/Poly.cs
@@ -398,6 +398,7 @@ public class PolyBuilder {
    public Poly Build () {
       PopBulge (mPts[0]);
       Poly.EFlags flags = mClosed ? Poly.EFlags.Closed : 0;
+      if (mClosed && mPts.Count > 1 && mPts[0].EQ (mPts[^1])) mPts.RemoveLast ();
       var extra = ImmutableArray<Poly.ArcInfo>.Empty;
       if (mExtra.Count > 0) {
          extra = [..mExtra];


### PR DESCRIPTION
Creating an obround "`M0,0H80Q80,50,2H0Q0,0,2Z`" creates a poly with duplicate endpoint (same as start point).

Similarly, using `PolyBuilder` if the endpoint repeats then closing the poly does not remove the duplicate endpoint.

---

A failing test was regenerated PR https://github.com/metamation/Pix/pull/198

