### PR TITLE
Using compiled expressions to create VNodes

### DIFF
--- a/Core/IO/AuType.cs
+++ b/Core/IO/AuType.cs
@@ -157,11 +157,12 @@ class AuType {
    // Methods ------------------------------------------------------------------
    /// <summary>Creates an instance of the object using its parameterless constructor</summary>
    public object CreateInstance () {
-      mConstructor ??= mType.GetConstructor (Public | Instance | NonPublic, []) ??
+      try {
+         return Activator.CreateInstance (mType)!;
+      } catch (MissingMethodException) {
          throw new AuException ($"No parameterless constructor found for {mType.FullName}");
-      return mConstructor.Invoke ([]);
+      }
    }
-   ConstructorInfo? mConstructor;
 
    /// <summary>Get a field of an object, given its name</summary>
    public AuField? GetField (ReadOnlySpan<byte> name) {

--- a/Lux/Scene/VNode.cs
+++ b/Lux/Scene/VNode.cs
@@ -2,6 +2,7 @@
 // ╔═╦╦═╦╦╬╣ VNode.cs
 // ║║║║╬║╔╣║ Implements the VNode class (base class for all visual nodes)
 // ╚╩═╩═╩╝╚╝ ───────────────────────────────────────────────────────────────────────────────────────
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace Nori;
@@ -113,16 +114,16 @@ public abstract class VNode {
    public static VNode MakeFor (object obj) {
       ArgumentNullException.ThrowIfNull (obj);
       var type = obj.GetType ();
-      if (!mBuilders.TryGetValue (type, out var ci)) {
+      if (!mBuilders.TryGetValue (type, out var de)) {
          foreach (var kvp in mBuilders)
             if (kvp.Key.IsAssignableFrom (type)) {
-               ci = mBuilders[type] = kvp.Value;
+               de = mBuilders[type] = kvp.Value;
                break;
             }
-         if (ci == null)
+         if (de == null)
             throw new Exception ($"No VNode found for {obj.GetType ().FullName}");
       }
-      return (VNode)ci.Invoke ([obj]);
+      return de.Invoke (obj);
    }
 
    /// <summary>Called when geometry has changed and complete redraw of this VNode is needed</summary>
@@ -159,14 +160,20 @@ public abstract class VNode {
                // parameters of the line, there should be a single LineVM that handles all those
                // cases in its Draw() method
                var args = ci.GetParameters ();
-               if (args.Length == 1) mBuilders.Add (args[0].ParameterType, ci);
+               if (args.Length == 1) {
+                  var paramExpr = Expression.Parameter (typeof (object));
+                  var newExpr = Expression.New (ci, Expression.Convert (paramExpr, args[0].ParameterType));
+                  var lambda = Expression.Lambda<Func<object, VNode>> (newExpr, paramExpr);
+                  var ctorDelegate = lambda.Compile ();
+                  mBuilders.Add (args[0].ParameterType, ctorDelegate);
+               }
             }
          }
       }
    }
    // This dictionary maps particular domain types (like Poly, Text etc) to constructors
    // in appropriate VNode types (like PolyVN, TextVN etc)
-   static readonly Dictionary<Type, ConstructorInfo> mBuilders = [];
+   static readonly Dictionary<Type, Func<object, VNode>> mBuilders = [];
    // These are the assemblies we have already searched to find VNode-derived types
    static readonly HashSet<Assembly> mAssemblies = [];
 


### PR DESCRIPTION
The static function `VNode VNode.MakeFor (object obj)` is called many times. For example, in a 3D model with 1000 surfaces, it will be called 1000 times. Currently, it is using ConstructorInfo.Invoke () which is about 3 - 5 times slower than using compiled delegates.

However, creating compiled delegates has a single large onetime cost at start-up. It is adding about 25ms to startup time when you call Lux.RegisterAssembly (). I think it is because of the framework warming up for runtime compilation. It does not matter how many VNode classes are there; it is the first call to Expression.Lambda ().Compile () that takes most of the time.

@tarydon , It is you call if this minor runtime speed-up is worth the large start-up time increase. If a project is anyway using compiled delegates elsewhere, it might be worth it!