### PR TITLE
Using Activator.CreateInstance () instead of ConstructorInfo.Invoke ([])

### DIFF
--- a/Core/IO/AuType.cs
+++ b/Core/IO/AuType.cs
@@ -156,11 +156,12 @@ class AuType {
 
    // Methods ------------------------------------------------------------------
    public object CreateInstance () {
-      mConstructor ??= mType.GetConstructor (Public | Instance | NonPublic, []) ??
+      try {
+         return Activator.CreateInstance (mType, nonPublic:true)!;
+      } catch (MissingMethodException) {
          throw new AuException ($"No parameterless constructor found for {mType.FullName}");
-      return mConstructor.Invoke ([]);
+      }
    }
-   ConstructorInfo? mConstructor;
 
    /// <summary>Get a field of an object, given its name</summary>
    public AuField? GetField (ReadOnlySpan<byte> name) {


### PR DESCRIPTION
Using `Activator.CreateInnstance ()` is found to be roughly 2x faster than calling `ConstructorInfo.Invoke ([])` on a cached ConstructorInfo.

https://www.joelverhagen.com/blog/2020/11/dynamically-activate-objects-net