### PR TITLE
VNode must be replugable into the Scene

### DIFF
--- a/Lux/Scene/VNode.cs
+++ b/Lux/Scene/VNode.cs
@@ -407,7 +407,7 @@ public abstract class VNode {
       }
       mFamily.ReleaseChain (ref mChildren);
       mFreeIDs.Push (Id); mNodes[Id] = null;
-      mGeometryDirty = mChildrenAdded = true;
+      mGeometryDirty = mChildrenAdded = true; mKnownChildren = 0;
       Id = 0;
    }
 


### PR DESCRIPTION
Currently, a `VNode` with `ChildSource` set is not reusable once detached from the scene. Just setting `mKnownChildren = 0` on `VNode.Deregister ()` seems to do the trick.