### PR TITLE
Scene must be repluggable

### DIFF
--- a/Lux/Lux.cs
+++ b/Lux/Lux.cs
@@ -42,7 +42,7 @@ public static partial class Lux {
       set {
          mUIScene?.Detach ();
          BackFacesPink = false;
-         mUIScene = value; mViewBound.OnNext (0); Redraw ();
+         mUIScene = value; mUIScene?.Attach (); mViewBound.OnNext (0); Redraw ();
          HW.CursorVisible = mUIScene?.CursorVisible ?? true;
       }
    }

--- a/Lux/Scene/Scene.cs
+++ b/Lux/Scene/Scene.cs
@@ -31,8 +31,10 @@ public abstract class Scene {
    public VNode? Root {
       get => mRoot;
       set {
-         mRoot?.Deregister ();
-         (mRoot = value)?.Register ();
+         if (miAttached) {
+            mRoot?.Deregister ();
+            (mRoot = value)?.Register ();
+         } else mRoot = value;
       }
    }
    VNode? mRoot;
@@ -66,8 +68,11 @@ public abstract class Scene {
    }
    protected Vec2S mViewport;
 
+   internal void Attach () { miAttached = true; mRoot?.Register (); }
+   bool miAttached = false;
+
    /// <summary>Called when the scene is detached from the Lux renderer</summary>
-   public void Detach () { Detached (); mRoot?.Deregister (); }
+   internal void Detach () { Detached (); mRoot?.Deregister (); miAttached = false; }
 
    /// <summary>Override this to zoom in or out about the given position (in pixels)</summary>
    public void Zoom (Vec2S pos, double factor) {


### PR DESCRIPTION
Currently, a Scene once detached is not reusable. For example, a Scene once detached by setting `Lux.UIScene` to null or some other Scene cannot be reused; setting it back on Lux.UIScene causes a crash! The issue is asymmetry in the way its Root node is registered and deregistered. When the Scene is replugged, Register () on its Root node is not called again.

Fix: Call Root.Register () only when the Scene is plugged into Lux.UIScene.

- Reuse of Scene is desirable when the window can have multiple document tabs open.