### PR TITLE
Change to Line3D.geom to nudge lines towards camera

### DIFF
--- a/Wad/GL/Shader/Line3D.geom
+++ b/Wad/GL/Shader/Line3D.geom
@@ -20,17 +20,17 @@ void main (void) {
    dir *= 0.25;
 
    gDist = width * 2.9;
-   gl_Position = vec4 (VPScale * (p0 + perpdir - dir), vert0.z, 1);
+   gl_Position = vec4 (VPScale * (p0 + perpdir - dir), vert0.z - 0.001 * vert0.w, 1);
    EmitVertex ();
 
-   gl_Position = vec4 (VPScale * (p1 + perpdir + dir), vert1.z, 1);   
+   gl_Position = vec4 (VPScale * (p1 + perpdir + dir), vert1.z - 0.001 * vert1.w, 1);   
    EmitVertex ();
 
    gDist = -width * 2.9;
-   gl_Position = vec4 (VPScale * (p0 - perpdir - dir), vert0.z, 1);
+   gl_Position = vec4 (VPScale * (p0 - perpdir - dir), vert0.z - 0.001 * vert0.w, 1);
    EmitVertex();
 
-   gl_Position = vec4 (VPScale * (p1 - perpdir + dir), vert1.z, 1);
+   gl_Position = vec4 (VPScale * (p1 - perpdir + dir), vert1.z - 0.001 * vert1.w, 1);
    EmitVertex ();
 
    EndPrimitive ();


### PR DESCRIPTION
I noticed that the stencil lines are not as smooth as they should be. I tried GL.Enable (PolygonOffset) but I did not see much difference. However, by editing Line3D.geom shader code, I found marked difference. See snapshot below

<img width="647" height="159" alt="image" src="https://github.com/user-attachments/assets/d4e0ab3c-3ecc-4ed3-8d15-b614594a215a" />

I am not sure if nudging by 0.001 is a good idea in the shader. polygon offset fill should have done it, but for some reason it seems to have no effect (may be my graphics card does not support it.)

@tarydon , This branch is created to bring this to your attention.