### PR TITLE
Freak bound computation issues

### DIFF
--- a/Core/IO/DXF/DXFReader.cs
+++ b/Core/IO/DXF/DXFReader.cs
@@ -139,7 +139,11 @@ public partial class DXFReader {
             else mPB.Arc (Pt, Bulge);
          }
          if (mClosedPoly == true) mPB.Close ();
-         Add (mPB.Build ());
+         var p = mPB.Build ();
+         // Pix#351 Poly with extraordinary extents (eg E+78) [Bound uses float and this value becomes INF there]
+         var b = p.GetBound ();
+         if (double.IsFinite (b.Width) && double.IsFinite (b.Height))
+            Add (p);
          Vertex.Clear (); 
       }
       mClosedPoly = null;
@@ -232,6 +236,7 @@ public partial class DXFReader {
             break;
 
          case TEXT:
+            if (Text.Length == 0) break;
             int hAlign = I2 > 2 ? 0 : I2.Clamp (0, 2), vAlign = 3 - I3.Clamp (0, 3);
             align = (ETextAlign)(vAlign * 3 + hAlign + 1);
             Point2 pos = align == ETextAlign.BaseLeft ? Pt0 : Pt1;

--- a/Core/IO/DXF/DXFReader.cs
+++ b/Core/IO/DXF/DXFReader.cs
@@ -236,7 +236,6 @@ public partial class DXFReader {
             break;
 
          case TEXT:
-            if (Text.Length == 0) break;
             int hAlign = I2 > 2 ? 0 : I2.Clamp (0, 2), vAlign = 3 - I3.Clamp (0, 3);
             align = (ETextAlign)(vAlign * 3 + hAlign + 1);
             Point2 pos = align == ETextAlign.BaseLeft ? Pt0 : Pt1;


### PR DESCRIPTION
The drawing had a weird contour (with values like E+95) which translates to INF for float variables.
This results in blank display, where even the mouse does not show up!
**Note**: This also ends up removing the erroneous contour, w/o warning!
