### PR TITLE
Fixed Cleanup crash Pix.416

### DIFF
--- a/Core/Geom/Bound.cs
+++ b/Core/Geom/Bound.cs
@@ -231,7 +231,7 @@ public readonly struct Bound2 : IEQuable<Bound2> {
    /// <summary>Construct a Bound2  that encompasses all the given Bound2 (union)</summary>
    public Bound2 (IEnumerable<Bound2> bounds) {
       (X, Y) = (new (), new ());
-      foreach (var b in bounds) { X += b.X; Y += b.Y; }
+      foreach (var b in bounds.Where (a => !a.IsEmpty)) { X += b.X; Y += b.Y; }
    }
 
    public override string ToString () => IsEmpty ? "Empty" : $"({X},{Y})";

--- a/Core/Geom/Poly.cs
+++ b/Core/Geom/Poly.cs
@@ -457,14 +457,13 @@ public partial class Poly {
       List<ArcInfo> extra = [];
       if (HasArcs) { // Cleanup the zero-length seg's extras
          foreach (var idx in Enumerable.Range (0, Extra.Length)) {
-            if (idx >= Extra.Length) break;
             if (skipIdxs.Contains (idx)) continue;
             extra.Add (Extra[idx]);
          }
       }
-      var flags = mFlags;
-      if (extra.Count == 0 || extra.Any (e => (e.Flags & EFlags.Arc) != 0))
-         flags &= ~EFlags.HasArcs;
+      var flags = extra.Count == 0 ? mFlags & ~EFlags.HasArcs : mFlags;
+      if (extra.Any (e => (e.Flags & EFlags.Arc) != 0))
+         flags |= EFlags.HasArcs;
       // Remove dup points
       var pts = mPts.Select ((pt, idx) => (pt, idx)).Where (a => !skipIdxs.Contains (a.idx)).Select (a => a.pt);
       result = new ([.. pts], [.. extra], flags);

--- a/Test/Poly/TPoly.cs
+++ b/Test/Poly/TPoly.cs
@@ -219,6 +219,10 @@ class PolyTests {
       // Mergeable last and first segs
       Poly.Parse ("M10,0H20V5H0V0H10Z").TryCleanup (out poly); poly!.Is ("M20,0V5H0V0Z");
       Poly.Parse ("M0,0Q10,-10,1V10Q0,0,1Z").TryCleanup (out poly); poly!.Is ("M10,-10V10Q10,-10,2Z");
+
+      // Circle - defined as 4 arcs interspersed with zero-length segs! [Pix#416]
+      Poly.Parse ("M-106.041834,326.551172V326.551172Q-103.541834,329.051172,1V329.051172Q-106.041834,331.551172,1V331.551172Q-108.541834,329.051172,1V329.051172Q-106.041834,326.551172,1Z")
+         .TryCleanup (out poly); poly!.Is ("C-106.041834,329.051172,2.5");
    }
 
    [Test (59, "Poly.Append tests")]


### PR DESCRIPTION
Bug in cleanup method fixed.

The other change is to ignore empty bound, which is due to text entity containing only "(c)" copyright symbol, which appears to be missing in the font file!