### PR TITLE
Added Mechanism.IsVisible property

### DIFF
--- a/Core/Sim/Mechanism.cs
+++ b/Core/Sim/Mechanism.cs
@@ -60,6 +60,12 @@ public partial class Mechanism {
    }
    bool _isColliding;
 
+   public bool IsVisible {
+      get => _isVisible;
+      set { if (Lib.Set (ref _isVisible, value)) Notify (EProp.Visibility); }
+   }
+   bool _isVisible = true;
+
    /// <summary>The definition vector for the joint</summary>
    /// - For a translation joint, this is the direction of translation
    /// - For a rotation joint, this is the direction of the rotation axis. The

--- a/Lux/Scene/VNode.cs
+++ b/Lux/Scene/VNode.cs
@@ -244,7 +244,7 @@ public abstract class VNode {
    /// TODO: Check we are disconnecting correctly
    protected virtual void OnChanged (EProp prop) {
       switch (prop) {
-         case EProp.Geometry: Redraw (); break;
+         case EProp.Geometry or EProp.Visibility: Redraw (); break;
          case EProp.Attributes or EProp.Xfm or EProp.Selected 
          or EProp.JValue or EProp.Colliding: Lux.Redraw (); break;
       }

--- a/Lux/VNodes/MechanismVN.cs
+++ b/Lux/VNodes/MechanismVN.cs
@@ -14,6 +14,6 @@ public class MechanismVN (Mechanism mMech) : VNode (mMech) {
    }
 
    public override void Draw () {
-      if (mMech.Mesh != null) Lux.Mesh (mMech.Mesh, EShadeMode.Phong);
+      if (mMech.IsVisible && mMech.Mesh != null) Lux.Mesh (mMech.Mesh, EShadeMode.Phong);
    }
 }


### PR DESCRIPTION
When an object of a VNode becomes hidden (EProp.Visibility changes), should we stop rendering its children too?

This implementation continues to render the children too as 
1. It is the desired behavior for Mechanisms 
2. The change in code is simpler. We would otherwise have to make changes to VNode.Render (). 