### PR TITLE
Fixed crash due to null Poly.Extra

### DIFF
--- a/Core/Geom/PolyOps.cs
+++ b/Core/Geom/PolyOps.cs
@@ -766,12 +766,12 @@ public partial class Poly {
       if (pts[0].EQ (pts[^1])) {
          flags |= EFlags.Closed; pts = [.. pts.SkipLast (1)];
       }
-      if (!a.HasArcs && !b.HasArcs) result = new Poly ([.. pts], default, flags);
+      if (!a.HasArcs && !b.HasArcs) result = new Poly ([.. pts], [], flags);
       else {
          var extra = new List<ArcInfo> (a.Count + b.Count);
          for (int i = 0; i < a.Count; i++)
             extra.Add (a.Extra.SafeGet (i));
-         if (!b.Extra.IsDefault) extra.AddRange (b.Extra);
+         extra.AddRange (b.Extra);
          result = new Poly ([.. pts], [.. extra], flags | EFlags.HasArcs);
       }
       return true;


### PR DESCRIPTION

```
ImmutableArray<int> arr = default;
Console.WriteLine (arr.Length); // No warning! And causes System.NullReferenceException

List<int> list = default;
Console.WriteLine (list.Count); // Warning: Dereference of a possibly null reference.

ImmutableArray<int> arr2 = [];
Console.WriteLine (arr2.Length); // Okay
```
No warning, because `ImmutableArray` is a `struct`.

In case of this issue, the `Poly.Extra` is inadvertently being initialized via `default`, causing the crash.